### PR TITLE
Move uswds to its own js bundle and scss

### DIFF
--- a/_www.foia.gov-canary/about.html
+++ b/_www.foia.gov-canary/about.html
@@ -21,8 +21,7 @@
 
 <script type="text/javascript" src="/scripts/breakout.js"></script>
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <script type="text/javascript" src="qtip/jquery-1.3.2.min.js"></script>
 <script type="text/javascript" src="qtip/jquery.qtip-1.0.0-rc3.min.js"></script>

--- a/_www.foia.gov-canary/data.html
+++ b/_www.foia.gov-canary/data.html
@@ -23,8 +23,7 @@
 
 <script type="text/javascript" src="tablehover.js"></script>
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <script type="text/javascript" src="qtip/jquery-1.3.2.min.js"></script>
 <script type="text/javascript" src="qtip/jquery.qtip-1.0.0-rc3.min.js"></script>

--- a/_www.foia.gov-canary/how-to.html
+++ b/_www.foia.gov-canary/how-to.html
@@ -21,8 +21,7 @@
 
 <script type="text/javascript" src="/scripts/breakout.js"></script>
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <script type="text/javascript" src="qtip/jquery-1.3.2.min.js"></script>
 <script type="text/javascript" src="qtip/jquery.qtip-1.0.0-rc3.min.js"></script>

--- a/_www.foia.gov-canary/index.html
+++ b/_www.foia.gov-canary/index.html
@@ -25,8 +25,7 @@
 
 <script type="text/javascript" src="tablehover.js"></script>
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <script type="text/javascript" src="qtip/jquery-1.3.2.min.js"></script>
 <script type="text/javascript" src="qtip/jquery.qtip-1.0.0-rc3.min.js"></script>

--- a/_www.foia.gov-canary/react.html
+++ b/_www.foia.gov-canary/react.html
@@ -11,8 +11,7 @@
 <meta name="dc.date.created" content="2011-03-14" />
 
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <link rel="stylesheet" type="text/css" href="/foia-style.css" />
 <title>FOIA.gov - Freedom of Information Act</title>

--- a/_www.foia.gov-canary/reports.html
+++ b/_www.foia.gov-canary/reports.html
@@ -23,8 +23,7 @@
 
 <script type="text/javascript" src="tablehover.js"></script>
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <script type="text/javascript" src="qtip/jquery-1.3.2.min.js"></script>
 <script type="text/javascript" src="qtip/jquery.qtip-1.0.0-rc3.min.js"></script>

--- a/_www.foia.gov-canary/request.html
+++ b/_www.foia.gov-canary/request.html
@@ -11,8 +11,7 @@
 <meta name="dc.date.created" content="2011-03-14" />
 
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <link rel="stylesheet" type="text/css" href="/foia-style.css" />
 <title>FOIA.gov - Freedom of Information Act: Create a request</title>

--- a/_www.foia.gov-canary/search.html
+++ b/_www.foia.gov-canary/search.html
@@ -13,8 +13,7 @@
 
 <script type="text/javascript" src="/scripts/breakout.js"></script>
 
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 
 <script type="text/javascript" src="qtip/jquery-1.3.2.min.js"></script>
 <script type="text/javascript" src="qtip/jquery.qtip-1.0.0-rc3.min.js"></script>

--- a/js/request.jsx
+++ b/js/request.jsx
@@ -2,6 +2,5 @@ import React from 'react';
 import { render } from 'react-dom';
 import Header from './header';
 
-require('uswds');
 
 render(<Header />, document.getElementById('react-app'));

--- a/js/uswds.js
+++ b/js/uswds.js
@@ -1,0 +1,1 @@
+import 'uswds';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,13 @@
 const path = require('path');
 
 module.exports = {
-  entry: './js/request.jsx',
+  entry: {
+    request: './js/request.jsx',
+    uswds: './js/uswds.js',
+  },
   output: {
     path: path.resolve(__dirname, 'www.foia.gov/assets/js'),
-    filename: 'request.bundle.js',
+    filename: '[name].bundle.js',
   },
   module: {
     loaders: [

--- a/www.foia.gov/_includes/head.html
+++ b/www.foia.gov/_includes/head.html
@@ -11,8 +11,7 @@
 {% for script in page.scripts %}
 <script type="text/javascript" src="{{ script }}"></script>
 {% endfor %}
-<!--temp home for USWDS JS require statement -->
-<script src="/assets/js/request.bundle.js"></script>
+<script src="/assets/js/uswds.bundle.js"></script>
 {% unless page.use-uswds %}
 {% include legacy/head.html %}
 {% endunless %}

--- a/www.foia.gov/_layouts/default.html
+++ b/www.foia.gov/_layouts/default.html
@@ -21,6 +21,11 @@
 {% endunless %}
 {% include footer.html %}
 </div>
+{% comment %}
+`page.init` is used for the legacy pages.
+`page.bundle` is used for the non-legacy pages.
+{% endcomment %}
 {% if page.init %}<script type="text/javascript" src="{{ page.init | prepend: "/" | prepend: site.baseurl }}"></script>{% endif %}
+{% if page.bundle %}<script type="text/javascript" src="{{ page.bundle | append: ".bundle.js" | prepend: "/assets/js/" | prepend: site.baseurl }}" ></script>{% endif %}
 </body>
 </html>

--- a/www.foia.gov/_sass/_uswds.scss
+++ b/www.foia.gov/_sass/_uswds.scss
@@ -1,0 +1,8 @@
+// Variable overrides
+$font-serif: Georgia, 'Times New Roman', Times, serif;
+
+// Relative font and image file paths
+$font-path:   '/assets/fonts' !default;
+$image-path:  '/assets/img' !default;
+
+@import '../../node_modules/uswds/src/stylesheets/uswds';

--- a/www.foia.gov/foia-style.scss
+++ b/www.foia.gov/foia-style.scss
@@ -8,10 +8,7 @@
 @import "foia-legacy.css";
 
 // USWDS
-@import '../../node_modules/uswds/src/stylesheets/uswds.scss';
-
-// Variable overrides
-$font-serif: Georgia, 'Times New Roman', Times, serif;
+@import "uswds";
 
 // SMACSS https://smacss.com/
 @import "base";


### PR DESCRIPTION
This moves uswds js to its own bundle so that it can be included independently of `request.bundle.js`

I also moved the uswds sass to its own file so that we can keep any overrides there. Seems cleaner to me.