### PR TITLE
adding terms

### DIFF
--- a/js/components/foia_request_form.jsx
+++ b/js/components/foia_request_form.jsx
@@ -56,6 +56,11 @@ function FoiaRequestForm({ formData, isSubmitting, onSubmit, requestForm, submis
     >
       <div id="foia-request-form_submit" className="foia-request-form_submit">
         <p>Please review the information you’ve entered and submit.</p>
+        <p>
+          You should hear from the agency you’ve submitted a records request to
+          within 10 days. If you don’t hear from the agency, please reach out
+          using the contact information provided to you on this site.
+        </p>
         <button type="submit">Submit</button>
         { submissionResult.errorMessage &&
           <div>

--- a/js/components/progress_bar.jsx
+++ b/js/components/progress_bar.jsx
@@ -20,7 +20,7 @@ function ProgressBar({ sections }) {
       }
       <li key="submit">
         <a href="#foia-request-form_submit">
-          <span>Submit</span>
+          <span>Submission and confirmation</span>
         </a>
       </li>
     </ul>

--- a/js/components/tabs.jsx
+++ b/js/components/tabs.jsx
@@ -78,10 +78,12 @@ class Tabs extends Component {
                 <li>
                   <h5>The person to reach out to about your FOIA request is:</h5>
                   <FoiaPersonnel foiaPersonnel={personnel[0]} />
-                  <p>You can ask <span data-term="foia">FOIA</span> personnel
-                    about anything related to your request, including whether
-                    what you’re asking for is clear.  You can also reach out to
-                    follow up on your request after it’s been submitted.</p>
+                  <p>
+                    You can ask FOIA personnel about anything related to your
+                    request, including whether what you’re asking for is clear.
+                    You can also reach out to follow up on your request after
+                    it’s been submitted.
+                  </p>
                 </li>
                 <li>
                   <h5>The description of records you are requesting is

--- a/js/test/util/request_form/sectioned_form.test.js
+++ b/js/test/util/request_form/sectioned_form.test.js
@@ -69,8 +69,9 @@ describe('sectionedFormFromAgencyComponent()', () => {
   });
 
   describe('given an agencyComponent with formFields', () => {
-    describe('given "additional section" fields', () => {
-      // These are fields not matching any of the other fields
+    describe('given agency-component-specific fields', () => {
+      // These are fields not matching any of the other fields. The section
+      // selected is based on the isAgencySpecificFieldSection, currently hard-coded
       let agencyComponent;
       let result;
 
@@ -104,7 +105,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
 
         it('has a single section with uiSchema', () => {
           expect(uiSchema).to.deep.equal({
-            additional_fields: {
+            supporting_docs: {
               agency_specific_field: {
                 'ui:title': 'An agency specific field',
                 'ui:description': undefined,
@@ -145,14 +146,14 @@ describe('sectionedFormFromAgencyComponent()', () => {
             expect(jsonSchemaProperties).to.be.ok;
           });
 
-          it('has an additional fields property', () => {
-            expect(jsonSchemaProperties).to.have.property('additional_fields');
+          it('has an additional fields section property', () => {
+            expect(jsonSchemaProperties).to.have.property('supporting_docs');
           });
 
-          describe('additional_fields', () => {
+          describe('supporting_docs', () => {
             let additionalFields;
             beforeEach(() => {
-              additionalFields = jsonSchemaProperties.additional_fields;
+              additionalFields = jsonSchemaProperties.supporting_docs;
             });
 
             it('exists', () => {
@@ -180,7 +181,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
 
             it('sets description as section description', () => {
               // TODO this is hardcoded, would be nice to feed it stub data
-              expect(additionalFields).to.have.property('description', 'This addtional information may be helpful for the agency to fulfill your FOIA request.');
+              expect(additionalFields).to.have.property('description');
             });
 
             it('has the single field as a property', () => {
@@ -197,8 +198,9 @@ describe('sectionedFormFromAgencyComponent()', () => {
       });
     });
 
-    describe('given two "additional section" fields', () => {
-      // These are fields not matching any of the other fields
+    describe('given two agency-component-specific fields', () => {
+      // These are fields not matching any of the other fields. The section
+      // selected is based on the isAgencySpecificFieldSection, currently hard-coded
       let agencyComponent;
       let result;
 
@@ -235,8 +237,8 @@ describe('sectionedFormFromAgencyComponent()', () => {
         });
 
         it('has a single section with two fields and uiSchema properties', () => {
-          expect(uiSchema).to.have.property('additional_fields');
-          expect(uiSchema.additional_fields).to.have.all.keys([
+          expect(uiSchema).to.have.property('supporting_docs');
+          expect(uiSchema.supporting_docs).to.have.all.keys([
             'agency_specific_field1',
             'agency_specific_field2',
             'ui:order',
@@ -265,8 +267,8 @@ describe('sectionedFormFromAgencyComponent()', () => {
           });
 
           it('has a section property with its own jsonSchema properties with two fields', () => {
-            expect(jsonSchemaProperties.additional_fields).to.have.property('properties');
-            expect(jsonSchemaProperties.additional_fields.properties).to.have.all.keys([
+            expect(jsonSchemaProperties.supporting_docs).to.have.property('properties');
+            expect(jsonSchemaProperties.supporting_docs.properties).to.have.all.keys([
               'agency_specific_field1',
               'agency_specific_field2',
             ]);
@@ -300,7 +302,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
       it('calls webformFieldsToJsonSchema for each section', () => {
         expect(spy).to.have.been.calledTwice;
         expect(spy).to.have.been.calledWith(sinon.match.array, sinon.match({ id: 'requester_contact' }));
-        expect(spy).to.have.been.calledWith(sinon.match.array, sinon.match({ id: 'additional_fields' }));
+        expect(spy).to.have.been.calledWith(sinon.match.array, sinon.match({ id: 'supporting_docs' }));
       });
 
       describe('uiSchema', () => {
@@ -314,9 +316,9 @@ describe('sectionedFormFromAgencyComponent()', () => {
         });
 
         it('has two sections', () => {
-          expect(uiSchema).to.have.property('additional_fields');
+          expect(uiSchema).to.have.property('supporting_docs');
           expect(uiSchema).to.have.property('requester_contact');
-          expect(uiSchema.additional_fields).to.have.all.keys([
+          expect(uiSchema.supporting_docs).to.have.all.keys([
             'ui:order',
             'agency_specific_field',
           ]);
@@ -348,10 +350,10 @@ describe('sectionedFormFromAgencyComponent()', () => {
           });
 
           it('has two sections', () => {
-            expect(jsonSchemaProperties).to.have.property('additional_fields');
+            expect(jsonSchemaProperties).to.have.property('supporting_docs');
             expect(jsonSchemaProperties).to.have.property('requester_contact');
 
-            expect(jsonSchemaProperties.additional_fields.properties).to.have.all.keys([
+            expect(jsonSchemaProperties.supporting_docs.properties).to.have.all.keys([
               'agency_specific_field',
             ]);
             expect(jsonSchemaProperties.requester_contact.properties).to.have.all.keys([

--- a/js/test/util/request_form/sectioned_form.test.js
+++ b/js/test/util/request_form/sectioned_form.test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import chaiSinon from 'sinon-chai';
 
 import wfjs from '../../../util/request_form/webform_to_json_schema';
-import formSections from '../../../util/request_form/form_sections';
+import sectionedForm from '../../../util/request_form/sectioned_form';
 
 
 chai.use(chaiSinon);
@@ -32,7 +32,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
         formFields: [],
       };
 
-      result = formSections.sectionedFormFromAgencyComponent(agencyComponent);
+      result = sectionedForm.sectionedFormFromAgencyComponent(agencyComponent);
     });
 
     it('does not call webformFieldsToJsonSchema', () => {
@@ -53,8 +53,8 @@ describe('sectionedFormFromAgencyComponent()', () => {
         jsonSchema = result.jsonSchema;
       });
 
-      it('has a title matching agency component', () => {
-        expect(jsonSchema).to.have.property('title', agencyComponent.title);
+      it('has a title "Make your request"', () => {
+        expect(jsonSchema).to.have.property('title', 'Make your request');
       });
 
       it('has a type', () => {
@@ -85,7 +85,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
           ],
         };
 
-        result = formSections.sectionedFormFromAgencyComponent(agencyComponent);
+        result = sectionedForm.sectionedFormFromAgencyComponent(agencyComponent);
       });
 
       it('calls webformFieldsToJsonSchema', () => {
@@ -127,8 +127,8 @@ describe('sectionedFormFromAgencyComponent()', () => {
           expect(jsonSchema).to.be.ok;
         });
 
-        it('has a title matching agency component', () => {
-          expect(jsonSchema).to.have.property('title', agencyComponent.title);
+        it('has a title "Make your request"', () => {
+          expect(jsonSchema).to.have.property('title', 'Make your request');
         });
 
         it('has a type', () => {
@@ -175,7 +175,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
 
             it('sets title as section title', () => {
               // TODO this is hardcoded, would be nice to feed it stub data
-              expect(additionalFields).to.have.property('title', 'Additional fields');
+              expect(additionalFields).to.have.property('title', 'Additional information');
             });
 
             it('sets description as section description', () => {
@@ -217,7 +217,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
           ],
         };
 
-        result = formSections.sectionedFormFromAgencyComponent(agencyComponent);
+        result = sectionedForm.sectionedFormFromAgencyComponent(agencyComponent);
       });
 
       it('calls webformFieldsToJsonSchema once', () => {
@@ -294,7 +294,7 @@ describe('sectionedFormFromAgencyComponent()', () => {
           ],
         };
 
-        result = formSections.sectionedFormFromAgencyComponent(agencyComponent);
+        result = sectionedForm.sectionedFormFromAgencyComponent(agencyComponent);
       });
 
       it('calls webformFieldsToJsonSchema for each section', () => {

--- a/js/util/glossary/terms.js
+++ b/js/util/glossary/terms.js
@@ -134,12 +134,31 @@ const terms = [
       Congress established nine categories of information that are not required to be released in response to a FOIA request because release would be harmful to a government or private interest. These categories are called "exemptions" from disclosures.
       <ul>
         <li>
-        <p><strong>Exemption 1</strong></p>
-        <p>Protects information that is specifically authorized, and properly classified, under criteria established by an Executive order to be kept secret in the interest of national defense or foreign policy.</p>
+          <strong><span data-term="exemption 1">Exemption 1</span></strong>
         </li>
         <li>
-        <p><strong>Exemption 2</strong></p>
-        <p>Protects information related solely to the internal personnel rules and practices of an agency.</p>
+          <strong><span data-term="exemption 2">Exemption 2</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 3">Exemption 3</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 4">Exemption 4</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 5">Exemption 5</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 6">Exemption 6</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 7 (A-F)">Exemption 7 (A-F)</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 8">Exemption 8</span></strong>
+        </li>
+        <li>
+          <strong><span data-term="exemption 9">Exemption 9</span></strong>
         </li>
       </ul>`,
   },
@@ -190,12 +209,14 @@ const terms = [
     term: 'Exemption 7 (A-F)',
     definition: `
       Protects records or information compiled for law enforcement purposes, but only to the extent that the production of such law enforcement records or information: 
--(A) could reasonably be expected to interfere with enforcement proceedings;
--(B) would deprive a person of a right to a fair trial or an impartial adjudication; 
--(C) could reasonably be expected to constitute an unwarranted invasion of personal privacy;
--(D) could reasonably be expected to disclose the identity of a confidential source, including a state, local, or foreign agency or authority or any private institution which furnished information on a confidential basis.  In the case of a record or information compiled by a criminal law enforcement authority in the course of a criminal investigation or by an agency conducting a lawful national security intelligence investigation, it also protects information furnished by the confidential source;
--(E) would disclose techniques and procedures for law enforcement investigations or prosecutions, or would disclose guidelines for law enforcement investigations or prosecutions if such disclosure could reasonably be expected to risk circumvention of the law;
--(F) could reasonably be expected to endanger the life or physical safety of any individual.`,
+      <ul>
+        <li>(A) could reasonably be expected to interfere with enforcement proceedings;</li>
+        <li>(B) would deprive a person of a right to a fair trial or an impartial adjudication; </li>
+        <li>(C) could reasonably be expected to constitute an unwarranted invasion of personal privacy;</li>
+        <li>(D) could reasonably be expected to disclose the identity of a confidential source, including a state, local, or foreign agency or authority or any private institution which furnished information on a confidential basis.  In the case of a record or information compiled by a criminal law enforcement authority in the course of a criminal investigation or by an agency conducting a lawful national security intelligence investigation, it also protects information furnished by the confidential source;</li>
+        <li>(E) would disclose techniques and procedures for law enforcement investigations or prosecutions, or would disclose guidelines for law enforcement investigations or prosecutions if such disclosure could reasonably be expected to risk circumvention of the law;</li>
+        <li>(F) could reasonably be expected to endanger the life or physical safety of any individual.</li>
+      </ul>`,
   },
   
   {

--- a/js/util/glossary/terms.js
+++ b/js/util/glossary/terms.js
@@ -131,7 +131,17 @@ const terms = [
   {
     term: 'Exemptions',
     definition: `
-      Congress established nine categories of information that are not required to be released in response to a FOIA request because release would be harmful to a government or private interest. These categories are called "exemptions" from disclosures.`,
+      Congress established nine categories of information that are not required to be released in response to a FOIA request because release would be harmful to a government or private interest. These categories are called "exemptions" from disclosures.
+      <ul>
+        <li>
+        <p><strong>Exemption 1</strong></p>
+        <p>Protects information that is specifically authorized, and properly classified, under criteria established by an Executive order to be kept secret in the interest of national defense or foreign policy.</p>
+        </li>
+        <li>
+        <p><strong>Exemption 2</strong></p>
+        <p>Protects information related solely to the internal personnel rules and practices of an agency.</p>
+        </li>
+      </ul>`,
   },
   
   {

--- a/js/util/glossary/terms.js
+++ b/js/util/glossary/terms.js
@@ -1,23 +1,81 @@
 /* eslint-disable */
 const terms = [
   {
-    term: 'agency component',
+    term: 'Administrative FOIA appeal',
     definition: `
-      A thing that receives a FOIA request. This is a catch-all term used by
-      OIP to refer to departments, bureaus, and offices that receive FOIA
-      requests.`,
+      An independent review of the initial determination made in response to a FOIA request. Requesters who are dissatisfied with the response made on their initial request have a statutory right to appeal that initial determination to an office within the agency which will then conduct an independent review.
+`,
+  },
+  
+  {
+    term: 'Agency record',
+    definition: `
+      Any record that is created or obtained by a federal agency, and under agency control when the request is received.`,
+  },
+  
+  {
+    term: 'Annual FOIA report',
+    definition: `
+      A report required to be filed each year with the Department of Justice by all federal agencies detailing the agency’s  administration of the FOIA.  Annual FOIA Reports contain detailed statistics on the number of FOIA requests and appeals received, processed, and pending at each agency.  All of the data from agency Annual FOIA Reports can be found on the “Reports” section of FOIA.gov where it can be easily reviewed, sorted, and compared by agency and over time.`,
+  },
+  
+  {
+    term: 'Annual FOIA Report Handbook',
+    definition: `
+      A comprehensive handbook published by the Department of Justice that includes all of the legal, procedural, and technical requirements concerning agency Annual FOIA Reports. The Handbook contains definitions for the various reporting metrics found on FOIA.gov.`,
+  },
+  
+  {
+    term: 'Backlog',
+    definition: `
+      The number of requests or administrative appeals that are pending beyond the statutory time period for a response.`,
+  },
+  
+  {
+    term: 'Certification of identity',
+    definition: `
+      To ensure that one person’s records are not inadvertently disclosed to another person, individuals requesting records about themselves may be asked to certify their identity by signing a sworn statement certifying that they are who they say they are.`,
   },
 
   {
-    term: 'Chief FOIA Officer',
+    term: 'Chief FOIA officer',
     definition: `
-      The person with agency-wide responsibility for oversight and support to
-      FOIA programs. The position is required by the Freedom of Information
-      Act and includes several additional responsibilities.`,
+      A high-level official designated within each agency who has overall responsibility for the agency’s compliance with the  FOIA.`,
   },
-
+  
   {
-    term: 'case management system',
+    term: 'Chief FOIA Officer Report',
+    definition: `
+     A report required to be filed with the Department of Justice, which details each agency’s progress in improving transparency and compliance with the FOIA.`,
+  },
+  
+  {
+    term: 'Compelling need',
+    definition: `
+     Under the FOIA a requester may qualify for expedited processing if they are able to demonstrate a “compelling need” for the records.  A “compelling need” can be established in one of two ways: (1) by establishing that the requester’s failure to obtain the records quickly "could reasonably be expected to pose an imminent threat to the life or physical safety of an individual;" or, (2) if the requester is a "person primarily engaged in established in disseminating information,” by demonstrating that there exists an "urgency to inform the public concerning actual or alleged Federal Government activity."
+`,
+  },
+  
+  {
+    term: 'Complex request',
+    definition: `
+      Complex requests typically seek a high volume of material or require additional steps to process such as the need to search for records in multiple locations.`,
+  },
+  
+  {
+    term: 'Component',
+    definition: `
+      For agencies that process requests on a decentralized basis, a "component" is an entity, also sometimes referred to as an Office, Division, Bureau, Center, or Directorate, within the agency that processes FOIA requests.`,
+  },
+  
+  {
+    term: 'Commercial-use requester',
+    definition: `
+      A request made by, or on behalf of someone who seeks information for a use or purpose that furthers the commercial, trade, or profit interests of the requester.`,
+  },
+  
+  {
+    term: 'Case management system',
     definition: `
       A system (usually electronic) to track the workflow of individual FOIA
       requests (cases). Each agency can have their own case management system
@@ -27,28 +85,314 @@ const terms = [
   },
 
   {
-    term: 'disclosability',
+    term: 'Consultation',
+    definition: `
+      When an agency locates a record that contains information of interest to another agency, it will ask for the views of that other agency on the disclosablity of the records before any final determination is made. This process is called a “consultation.”`,
+  },
+  
+    {
+    term: 'Decentralized agencies or decentralized FOIA process',
+    definition: `
+      When an agency is separated into components or offices and those individual components handle FOIA requests for their own records, the FOIA process is called “decentralized.” Most large federal agencies have a decentralized FOIA process, where requesters send their requests directly to the component or office of the agency that maintains the records they seek, and that component handles the request.`,
+  },
+
+  {
+    term: 'Disclosability',
     definition: `
       The degree to which a piece of information is disclosable. Often used
       when evaluating what information in a record is disclosable or what must
       be redacted.`,
   },
-  {
-
-    term: 'FOIA',
+  
+   {
+    term: 'Duplication fees',
     definition: `
-      The Freedom of Information Act which provides that any person has a right,
-      enforceable in court, to obtain access to federal agency records, except to the
-      extent that any portions of such records are protected from public disclosure by
-      one of nine exemptions or by one of three special law enforcement record
-      exclusions.`,
+      The cost for reproducing a copy of a record, or the information contained in it, necessary to respond to a FOIA request.  Copies can take the form of paper, audiovisual materials, or electronic records, among others.  With the exception of commercial-use requesters, the first 100 pages of duplication are free. `,
+  },
+  
+  {
+    term: 'Educational Institutions',
+    definition: `
+      Schools, including vocational schools, which operate a program of “scholarly research.”`,
+  },
+  
+  {
+    term: 'Equivalent full-time FOIA employees',
+    definition: `
+      An "equivalent full-time FOIA employee" is created by adding together the percentages of time dedicated to FOIA duties by employees performing less than full-time FOIA work.`,
+  },
+  
+  {
+    term: 'Exclusions',
+    definition: `
+      Three narrowly defined categories of law enforcement records for which the law provides special protections where publicly acknowledging even the existence of the records could cause harm to law enforcement or national security interests.  The first exclusion protects against disclosure of a pending criminal law enforcement investigation where there is reason to believe that the target is unaware of the investigation and disclosure of its existence could reasonably be expected to interfere with enforcement proceedings. The second exclusion, which applies only to records maintained by criminal law enforcement agencies, protects against disclosure of unacknowledged, confidential informants. The third exclusion, which applies only to the FBI, protects against disclosure of foreign intelligence or counterintelligence, or international terrorism records, when the existence of those records is classified.`,
+  },
+  
+  {
+    term: 'Exemptions',
+    definition: `
+      Congress established nine categories of information that are not required to be released in response to a FOIA request because release would be harmful to a government or private interest. These categories are called "exemptions" from disclosures.`,
+  },
+  
+  {
+    term: 'Exemption 3 statute',
+    definition: `
+      A federal statute that provides protection from disclosure under FOIA for certain information.  For a statute to qualify as an “Exemption 3 statute” it must either (1) require that the matters be withheld from the public in such a manner as to leave no discretion on the issue; or (2) establish particular criteria for withholding or refers to particular types of matters to be withheld.  An Exemption 3 statute must also cite specifically to subsection (b)(3) of the FOIA if enacted after October 28, 2009.`,
+  },
+  
+  {
+    term: 'Exemption 1',
+    definition: `
+      Protects information that is specifically authorized, and properly classified, under criteria established by an Executive order to be kept secret in the interest of national defense or foreign policy.`,
+  },
+  
+  {
+    term: 'Exemption 2',
+    definition: `
+      Protects information related solely to the internal personnel rules and practices of an agency.`,
+  },
+  
+  {
+    term: 'Exemption 3',
+    definition: `
+      Protects information specifically exempted from disclosure by another statute, if that statute either:  (1) requires that the matters be withheld from the public in such a manner as to leave no discretion on the issue; or (2) establishes particular criteria for withholding or refers to particular types of matters to be withheld.  An Exemption 3 statute must also cite specifically to subsection (b)(3) of the FOIA if enacted after October 28, 2009.`,
+  },
+  
+  {
+    term: 'Exemption 4',
+    definition: `
+       Protects trade secrets and commercial or financial information that has been “obtained from a person” and that is privileged or confidential.`,
+  },
+  
+  {
+    term: 'Exemption 5',
+    definition: `
+      Protects inter- or intra-agency records that are normally privileged in the civil discovery context, provided that the deliberative process privilege shall not apply to records created 25 years or more before the date on which the records were requested.`,
+  },
+  
+  {
+    term: 'Exemption 6',
+    definition: `
+       Protects information about individuals in personnel and medical files and similar files when the disclosure of that information would constitute a clearly unwarranted invasion of personal privacy.`,
+  },
+  
+  {
+    term: 'Exemption 7 (A-F)',
+    definition: `
+      Protects records or information compiled for law enforcement purposes, but only to the extent that the production of such law enforcement records or information: 
+-(A) could reasonably be expected to interfere with enforcement proceedings;
+-(B) would deprive a person of a right to a fair trial or an impartial adjudication; 
+-(C) could reasonably be expected to constitute an unwarranted invasion of personal privacy;
+-(D) could reasonably be expected to disclose the identity of a confidential source, including a state, local, or foreign agency or authority or any private institution which furnished information on a confidential basis.  In the case of a record or information compiled by a criminal law enforcement authority in the course of a criminal investigation or by an agency conducting a lawful national security intelligence investigation, it also protects information furnished by the confidential source;
+-(E) would disclose techniques and procedures for law enforcement investigations or prosecutions, or would disclose guidelines for law enforcement investigations or prosecutions if such disclosure could reasonably be expected to risk circumvention of the law;
+-(F) could reasonably be expected to endanger the life or physical safety of any individual.`,
+  },
+  
+  {
+    term: 'Exemption 8',
+    definition: `
+      Protects information contained in or related to examination, operating, or condition reports prepared by, on behalf of, or for the use of, an agency responsible for the regulation or supervision of financial institutions.`,
+  },
+  
+  {
+    term: 'Exemption 9',
+    definition: `
+      Protects geological and geophysical information and data, including maps, concerning wells.`,
+  },
+  
+  
+  {
+    term: 'Expedited processing',
+    definition: `
+      In certain limited situations, FOIA requesters can ask that their request be processed ahead of other pending requests. This is called expedited processing. The standards for expedited processing are set out in the FOIA and in the regulations of each federal agency.`,
+  },
+  
+  {
+    term: 'Fee waiver',
+    definition: `
+      You may request a fee waiver when making your request.  Under the FOIA, fee waivers are limited to situations in which a requester can show that the disclosure of the requested information is in the public interest because it is likely to contribute significantly to public understanding of the operations and activities of the government and is not primarily in the commercial interest of the requester.  Requests for fee waivers from individuals who are seeking records pertaining to themselves usually do not meet this standard.  In addition, a requester's inability to pay fees is not a legal basis for granting a fee waiver.`,
+  },
+  
+  {
+    term: 'First party request',
+    definition: `
+      When a requester seeks records about him or herself.`,
   },
 
   {
+    term: 'FOIA',
+    definition: `
+      Since 1967, the Freedom of Information Act (FOIA) has provided the public the right to request access to records from any federal agency.  It is often described as the law that keeps citizens in the know about their government.  Federal agencies are required to disclose any information requested under the FOIA unless that information falls under one of three narrow law enforcement exclusions or nine exemptions which protect interests such as personal privacy, national security, and law enforcement.
+The FOIA also requires agencies to proactively post online certain categories of information, including frequently requested records. `,
+  },
+  
+  {
+    term: 'FOIA.gov',
+    definition: `
+      FOIA.gov serves as the government’s comprehensive FOIA website for all information on the FOIA.   Among many other features, FOIA.gov provides a central resource for the public to understand the FOIA, to locate records that are already available online, and to learn how to make a request for information that is not yet publicly available.  Requesters can make a request to any agency subject to the FOIA using FOIA.gov. FOIA.gov also promotes agency accountability for the administration of the FOIA by graphically displaying the detailed statistics contained in agency Annual FOIA Reports, so that they can be compared by agency and over time.`,
+  },
+  
+  {
+    term: 'FOIA contact',
+    definition: `
+      The name, address and phone number at each agency or office where you can make a FOIA request.`,
+  },
+  
+  {
+    term: 'FOIA library',
+    definition: `
+      A web page (sometimes called an "electronic Reading Room”), typically on the agency’s FOIA website, where certain categories of records are proactively disclosed.  These FOIA Libraries contain both operational documents about the agency as well as records that have been frequently requested under the FOIA.Links to each agency’s FOIA Library are available on FOIA.gov when you select that agency.`,
+  },
+  
+    {
     term: 'FOIA Public Liaison',
     definition: `
-      Responsible for acting as the public contact for addressing concerns of
-      requesters related to FOIA administration. Designated by the Chief FOIA Officer.`,
+      The agency FOIA Public Liaison is an official who supervises the FOIA Requester Service Center.`,
+  },
+  
+  {
+    term: 'FOIA request',
+    definition: `
+      A request submitted to a federal agency asking for agency records on any topic.  A FOIA request can generally be made by any person and to any federal agency.`,
+  },
+  
+  {
+    term: 'FOIA request service center',
+    definition: `
+      The primary contact at each agency where you can call and ask questions about the FOIA process or your pending FOIA request, including the status of your request.`,
+  },
+  
+  {
+    term: 'Frequently requested records',
+    definition: `
+      Records released in response to a FOIA request that the agency determines have become or are likely to become the subject of subsequent requests for substantially the same records.  Under subsection (a)(2) of the FOIA, agencies proactively post online any releasable records that have been requested three or more times. `,
+  },
+  
+  {
+    term: 'Full denial',
+    definition: `
+      When an agency cannot release any records in response to a FOIA request, because, for example, the requested information is exempt from disclosure in its entirety or no records responsive to the request could be located.`,
+  },
+  
+  {
+    term: 'Full grant',
+    definition: `
+      When an agency is able to disclose all records in full in response to a FOIA request.`,
+  },
+  
+  {
+    term: 'Full-time FOIA employees',
+    definition: `
+      The number of staff at a department or agency who work on FOIA full time in their positions.`,
+  },
+  
+  {
+    term: 'Multi-track processing',
+    definition: `
+      A system that divides in-coming FOIA requests according to their complexity so that simple requests requiring relatively minimal search and review are placed in one processing track and more complex requests are placed in one or more other tracks. Requests granted expedited processing are placed in yet another track. Requests in each track are processed on a first in/first out basis.
+`,
+  },
+  
+  {
+    term: 'Noncommercial scientific institution',
+    definition: `
+      An institution operated solely for the purpose of conducting scientific research not intended to promote any particular product or industry.`,
+  },
+  
+   {
+    term: 'Partial grant/partial denial',
+    definition: `
+      When an agency is able to disclose portions of the records in response to a FOIA request, but must deny other portions of the request.`,
+  },
+  
+   {
+    term: 'Pending request or pending appeal',
+    definition: `
+      A FOIA request or administrative appeal for which an agency has not yet taken final action in all respects. This statistic is different from the number of backlogged requests or appeals, because it captures anything that is open at a given time including requests that are well within the statutory response time. `,
+  },
+  
+   {
+    term: 'Perfected request',
+    definition: `
+      A FOIA request which reasonably describes the records sought and is made in accordance with the agency's FOIA regulations.`,
+  },
+  
+   {
+    term: 'Proactive disclosures',
+    definition: `
+      Records made publicly available by agencies without waiting for a specific FOIA request. Agencies post on their websites a vast amount of material concerning their functions and mission. The FOIA itself requires agencies to make available certain categories of information, including final opinions and orders, specific policy statements, certain administrative staff manuals and frequently requested records.`,
+  },
+  
+   {
+    term: 'Processed request or processed appeal',
+    definition: `
+      The number of requests or appeals where the agency has completed its work and sent a final response to the requester. `,
+  },
+  
+   {
+    term: 'Received request or received appeal',
+    definition: `
+      A FOIA request or administrative appeal that an agency has received within a fiscal year. `,
+  },
+  
+   {
+    term: 'Referral',
+    definition: `
+      When an agency locates a record that originated with, or is of otherwise primary interest to another agency, it will forward that record to the other agency to process the record and to provide the final determination directly to the requester.  This process is called a “referral.”`,
+  },
+  
+   {
+    term: 'Representative of the news media',
+    definition: `
+      Any person or entity that gathers information of potential interest to a segment of the public, uses its editorial skills to turn the raw materials into a distinct work, and distributes that work to an audience.`,
+  },
+  
+   {
+    term: 'Requester category',
+    definition: `
+      For fee purposes, the FOIA separates requesters into three categories:  (1) commercial-use requesters; (2) representatives of the news media, noncommercial scientific institutions, and educational institutions; and (3) all other requesters.  Commercial-use requesters can be charged for review, search, and duplication.  Representatives of the news media, noncommercial scientific institutions, and educational institutions are only charged for search time, with the first two hours provided at no charge.  All other requesters are charged for search time and duplication, with the first 100 pages of duplication and two hours of search time provided at no charge. `,
+  },
+  
+  {
+    term: 'Review fees',
+    definition: `
+       Fees associated with the time that is necessary to review material to determine if it can be released, and all that is necessary to prepare material for release.`,
+  },
+  
+  {
+    term: 'Search',
+    definition: `
+      To review, manually or by automated means, agency records for the purpose of locating those records which are responsive to a request.`,
+  },
+  
+  {
+    term: 'Search fees',
+    definition: `
+      Fees associated with the the time spent searching for and retrieving records or information responsive to a request.  Representatives of the news media, non-commercial scientific insertions, and educational institutions are not charged search fees.  With the exceptions of commercial-use requesters, all other requesters are provided the first two hours of search time for free.`,
+  },
+  
+  {
+    term: 'Simple request',
+    definition: `
+      A FOIA request that an agency anticipates will involve a small volume of material or which it will be able to be processed relatively quickly.`,
+  },
+  
+  {
+    term: 'Third party request',
+    definition: `
+      When a requester seeks records about an individual other than themselves or another topic.`,
+  },
+  
+  {
+    term: 'Total number of full-time FOIA staff',
+    definition: `
+      The total number of staff at a department or agency who work on FOIA when adding together the number of Full-Time FOIA Employees and Equivalent Full-Time FOIA Employees.`,
+  },
+  
+  {
+    term: 'Unusual circumstances',
+    definition: `
+      Under “unusual circumstances” the agency can extend the 20 working-day response time in writing.  Unusual circumstances include when:  (I) the agency needs to search for and collect the requested records from field facilities or other establishments that are separate from the office processing the request; (II) the agency needs to search for, collect, and appropriately examine a voluminous amount of separate and distinct records which are demanded in a single request; or (III) the agency needs to consult with another agency or two or more components within its own agency.`,
   },
 
   {

--- a/js/util/request_form/domify.jsx
+++ b/js/util/request_form/domify.jsx
@@ -1,0 +1,14 @@
+/*
+ * domify
+ *
+ * Converts text to react elements. **Only use for known-safe content.**
+ */
+import React from 'react';
+
+function domify(content) {
+  /* eslint-disable react/no-danger */
+  return <div dangerouslySetInnerHTML={{ __html: content }} />;
+  /* eslint-enable react/no-danger */
+}
+
+export default domify;

--- a/js/util/request_form/form_sections.js
+++ b/js/util/request_form/form_sections.js
@@ -6,6 +6,8 @@
 import domify from './domify';
 
 
+// Order of sections is significant, this is the order they are rendered in
+// the form.
 export const FORM_SECTIONS = [
   {
     id: 'requester_contact',
@@ -15,35 +17,35 @@ export const FORM_SECTIONS = [
       your request for  information. Please note that not all of these fields
       are required.
     `,
+    // Ordering is significant
     fieldNames: [
-      // deprecated names https://github.com/18F/beta.foia.gov/issues/188
-      'prefix_title',
-      'first_name',
-      'last_name',
-      'middle_initial_middle_name',
-      'suffix',
-      'mailing_address_line_1',
-      'mailing_address_line_2',
-      'city',
-      'country',
-      'state_province',
-      'zip_postal_code',
-
-      'name_prefix_title',
+      // deprecated names refer to https://github.com/18F/beta.foia.gov/issues/188
+      'name_prefix_title', // deprecated
+      'prefix_title', // deprecated
       'name_first',
+      'first_name', // deprecated
       'name_middle_initial_middle',
+      'middle_initial_middle_name', // deprecated
       'name_last',
-      'name_suffix',
-      'address_line1',
-      'address_line2',
-      'address_city',
-      'address_state_province',
-      'address_country',
-      'address_zip_postal_code',
-      'phone_number',
-      'fax_number',
-      'company_organization',
+      'last_name', // deprecated
+      'name_suffix', // deprecated
+      'suffix', // deprecated
       'email',
+      'address_line1',
+      'mailing_address_line_1', // deprecated
+      'address_line2',
+      'mailing_address_line_2', // deprecated
+      'address_city',
+      'city', // deprecated
+      'address_state_province',
+      'state_province', // deprecated
+      'address_zip_postal_code',
+      'zip_postal_code', // deprecated
+      'address_country',
+      'country', // deprecated
+      'phone_number',
+      'company_organization',
+      'fax_number',
     ],
   },
 
@@ -59,6 +61,7 @@ export const FORM_SECTIONS = [
       determine exactly which records are being requested and where to locate
       them.
     `),
+    // Ordering is significant
     fieldNames: [
       'request_description',
     ],
@@ -75,6 +78,7 @@ export const FORM_SECTIONS = [
       also use this tool to upload documents providing context for your request
       to help FOIA personnel process your FOIA request.
     `),
+    // Ordering is significant
     fieldNames: [
       'attachments_supporting_documentation',
     ],
@@ -94,6 +98,7 @@ export const FORM_SECTIONS = [
       operations and activities of the government, and is not primarily in the
       commercial interest of the requester.
     `),
+    // Ordering is significant
     fieldNames: [
       'request_category',
       'fee_waiver',
@@ -121,6 +126,7 @@ export const FORM_SECTIONS = [
       government activity.  You should consult the agency’s FOIA regulations
       for any additional standards that may qualify for expedited processing.
     `),
+    // Ordering is significant
     fieldNames: [
       'expedited_processing',
       'expedited_processing_explanation',

--- a/js/util/request_form/form_sections.js
+++ b/js/util/request_form/form_sections.js
@@ -14,7 +14,7 @@ const FORM_SECTIONS = [
     title: 'Contact information',
     description: `
       The information you supply here will be used to provide a response for
-      your request for  information. Please note that not all of these fields
+      your request for information. Please note that not all of these fields
       are required.
     `,
     // Ordering is significant
@@ -55,7 +55,7 @@ const FORM_SECTIONS = [
     description: domify(`
       The description of the records you are requesting is important. The scope
       of your request can impact how quickly an agency could respond to your
-      request. Your description should be as  clear and specific as possible
+      request. Your description should be as clear and specific as possible
       and must give agency <span data-term="full-time foia employees">FOIA
       personnel</span> enough detail so that they are able to reasonably
       determine exactly which records are being requested and where to locate
@@ -92,7 +92,7 @@ const FORM_SECTIONS = [
     description: domify(`
       There is no initial <span data-term="fee waiver">fee</span> required to
       submit a FOIA request, but the FOIA does allow people requesting records
-      to be charged certain types of fees in some instances. If fees will be at
+      to be charged certain types of fees in some instances. If fees will be an
       issue in your request, you may request a waiver of those fees. Fee
       waivers are limited to situations in which a requester can show that the
       disclosure of the requested information is in the public interest because

--- a/js/util/request_form/form_sections.js
+++ b/js/util/request_form/form_sections.js
@@ -8,7 +8,7 @@ import domify from './domify';
 
 // Order of sections is significant, this is the order they are rendered in
 // the form.
-export const FORM_SECTIONS = [
+const FORM_SECTIONS = [
   {
     id: 'requester_contact',
     title: 'Contact information',
@@ -70,6 +70,8 @@ export const FORM_SECTIONS = [
   {
     id: 'supporting_docs',
     title: 'Additional information',
+    // This section is where the agency-component-specific fields go
+    isAgencySpecificFieldSection: true,
     description: domify(`
       If you are submitting a <span data-term="first party request">first party request</span>,
       use this tool to upload any required documentation (see the agency’s FOIA Reference
@@ -135,8 +137,4 @@ export const FORM_SECTIONS = [
 
 ];
 
-export const ADDITIONAL_FIELDS_SECTION = {
-  id: 'additional_fields',
-  title: 'Additional information',
-  description: 'This addtional information may be helpful for the agency to fulfill your FOIA request.',
-};
+export default FORM_SECTIONS;

--- a/js/util/request_form/form_sections.js
+++ b/js/util/request_form/form_sections.js
@@ -1,8 +1,20 @@
+/*
+ * FormSections
+ *
+ * Contains hard-coded form sections to split up the FOIA request form.
+ */
+import domify from './domify';
+
+
 export const FORM_SECTIONS = [
   {
     id: 'requester_contact',
-    title: 'Requester contact',
-    description: 'Complete the information describing yourself and how the agency can contact you about your request.',
+    title: 'Contact information',
+    description: `
+      The information you supply here will be used to provide a response for
+      your request for  information. Please note that not all of these fields
+      are required.
+    `,
     fieldNames: [
       // deprecated names https://github.com/18F/beta.foia.gov/issues/188
       'prefix_title',
@@ -37,8 +49,16 @@ export const FORM_SECTIONS = [
 
   {
     id: 'request_description',
-    title: 'Request description',
-    description: 'Describe the records you are requesting. Be as specific as possible.',
+    title: 'Your request',
+    description: domify(`
+      The description of the records you are requesting is important. The scope
+      of your request can impact how quickly an agency could respond to your
+      request. Your description should be as  clear and specific as possible
+      and must give agency <span data-term="full-time foia employees">FOIA
+      personnel</span> enough detail so that they are able to reasonably
+      determine exactly which records are being requested and where to locate
+      them.
+    `),
     fieldNames: [
       'request_description',
     ],
@@ -46,8 +66,15 @@ export const FORM_SECTIONS = [
 
   {
     id: 'supporting_docs',
-    title: 'Supporting documentation',
-    description: 'Include any supporting documentation related to your request.',
+    title: 'Additional information',
+    description: domify(`
+      If you are submitting a <span data-term="first party request">first party request</span>,
+      use this tool to upload any required documentation (see the agency’s FOIA Reference
+      Guide or FOIA regulations) to verify your identity <span data-term="certification of identity">
+      Certification of Identity</span> with the agency you are requesting information from. You can
+      also use this tool to upload documents providing context for your request
+      to help FOIA personnel process your FOIA request.
+    `),
     fieldNames: [
       'attachments_supporting_documentation',
     ],
@@ -55,22 +82,46 @@ export const FORM_SECTIONS = [
 
   {
     id: 'processing_fees',
-    title: 'Processing fees',
-    description: 'Under certain circumstances you may need to pay for processing fees.',
+    title: 'Fee waiver',
+    description: domify(`
+      There is no initial <span data-term="fee waiver">fee</span> required to
+      submit a FOIA request, but the FOIA does allow people requesting records
+      to be charged certain types of fees in some instances. If fees will be at
+      issue in your request, you may request a waiver of those fees. Fee
+      waivers are limited to situations in which a requester can show that the
+      disclosure of the requested information is in the public interest because
+      it is likely to contribute significantly to public understanding of the
+      operations and activities of the government, and is not primarily in the
+      commercial interest of the requester.
+    `),
     fieldNames: [
+      'request_category',
       'fee_waiver',
-      'fee_amount_willing',
       'fee_waiver_explanation',
+      'fee_amount_willing',
+      'processing_fees', // deprecated
     ],
   },
 
 
   {
-    id: 'delivery_method',
-    title: 'Delivery method',
-    description: 'How would you like to receive your request?',
+    id: 'expedited_processing',
+    title: 'Request expedited processing',
+    description: domify(`
+      You may be entitled to have your request processed on an <span
+      data-term="expedited processing">expedited basis</span> if you demonstrate a
+      <span data-term="compelling need">“compelling need”</span> or satisfy
+      any additional standards that may be included in the regulations of the
+      agency to which you are submitting your request.  A compelling need
+      exists only if you can establish: (1) that failure to
+      obtain records quickly could reasonably be expected to pose an imminent
+      threat to the life and safety of an individual, or (2) that you are a
+      person primarily engaged in disseminating information and there is an
+      urgency to inform the public concerning actual or alleged federal
+      government activity.  You should consult the agency’s FOIA regulations
+      for any additional standards that may qualify for expedited processing.
+    `),
     fieldNames: [
-      'delivery_method',
       'expedited_processing',
       'expedited_processing_explanation',
     ],
@@ -80,6 +131,6 @@ export const FORM_SECTIONS = [
 
 export const ADDITIONAL_FIELDS_SECTION = {
   id: 'additional_fields',
-  title: 'Additional fields',
+  title: 'Additional information',
   description: 'This addtional information may be helpful for the agency to fulfill your FOIA request.',
 };

--- a/js/util/request_form/form_sections.js
+++ b/js/util/request_form/form_sections.js
@@ -1,6 +1,4 @@
-import wfjs from './webform_to_json_schema';
-
-const FORM_SECTIONS = [
+export const FORM_SECTIONS = [
   {
     id: 'requester_contact',
     title: 'Requester contact',
@@ -80,87 +78,8 @@ const FORM_SECTIONS = [
 
 ];
 
-const ADDITIONAL_FIELDS_SECTION = {
+export const ADDITIONAL_FIELDS_SECTION = {
   id: 'additional_fields',
   title: 'Additional fields',
   description: 'This addtional information may be helpful for the agency to fulfill your FOIA request.',
-};
-
-const fieldToSectionMap = FORM_SECTIONS
-  .reduce(
-    (memo, section) =>
-      section
-        .fieldNames
-        .reduce((map, fieldName) => Object.assign(map, { [fieldName]: section }), memo),
-    {},
-  );
-
-
-function findSection(field) {
-  return field.name in fieldToSectionMap ?
-    fieldToSectionMap[field.name] :
-    ADDITIONAL_FIELDS_SECTION;
-}
-
-function bucketFieldsBySection(formFields) {
-  // Make sure to maintain the order by processing these in formFields order
-  return formFields
-    .reduce((form, field) => {
-      const section = findSection(field);
-      const sectionFields = form[section.id] || [];
-
-      sectionFields.push(field);
-      form[section.id] = sectionFields;
-      return form;
-    }, {});
-}
-
-// TODO make this a class so you can pass in the FORM_SECTIONS
-function sectionedFormFromAgencyComponent(agencyComponent) {
-  const fieldsBySection = bucketFieldsBySection(agencyComponent.formFields || []);
-
-  // Grab a list of sections, skipping empty sections
-  const sections = FORM_SECTIONS
-    .concat([ADDITIONAL_FIELDS_SECTION])
-    .filter(section => section.id in fieldsBySection);
-
-  const result = sections
-    .map((section) => {
-      // Use only the form fields in this section
-      const formFields = fieldsBySection[section.id];
-
-      const { jsonSchema, uiSchema } = wfjs.webformFieldsToJsonSchema(formFields, section);
-
-      // Pass a triplet for processing
-      return [section.id, jsonSchema, uiSchema];
-    })
-    .reduce((form, [sectionId, jsonSchema, uiSchema]) => {
-      form.properties[sectionId] = jsonSchema;
-      form.uiSchema[sectionId] = uiSchema;
-      return form;
-    }, { properties: {}, uiSchema: {} });
-
-  return {
-    jsonSchema: {
-      title: agencyComponent.title,
-      type: 'object',
-      properties: result.properties,
-    },
-    uiSchema: result.uiSchema,
-    sections,
-  };
-}
-
-function mergeSectionFormData(formData) {
-  return Object.keys(formData)
-    .reduce(
-      (form, sectionId) => Object.assign(form, formData[sectionId]),
-      {},
-    );
-}
-
-
-export default {
-  mergeSectionFormData,
-  sectionedFormFromAgencyComponent,
 };

--- a/js/util/request_form/index.js
+++ b/js/util/request_form/index.js
@@ -15,11 +15,11 @@
  * the individual sections' jsonSchema and uiSchema into a unified one.
  */
 
-import formSections from './form_sections';
+import sectionedForm from './sectioned_form';
 import wfjs from './webform_to_json_schema';
 
 export default {
-  mergeSectionFormData: formSections.mergeSectionFormData,
-  sectionedFormFromAgencyComponent: formSections.sectionedFormFromAgencyComponent,
+  mergeSectionFormData: sectionedForm.mergeSectionFormData,
+  sectionedFormFromAgencyComponent: sectionedForm.sectionedFormFromAgencyComponent,
   webformFieldsToJsonSchema: wfjs.webformFieldsToJsonSchema,
 };

--- a/js/util/request_form/sectioned_form.js
+++ b/js/util/request_form/sectioned_form.js
@@ -1,0 +1,82 @@
+import wfjs from './webform_to_json_schema';
+import { FORM_SECTIONS, ADDITIONAL_FIELDS_SECTION } from './form_sections';
+
+
+const fieldToSectionMap = FORM_SECTIONS
+  .reduce(
+    (memo, section) =>
+      section
+        .fieldNames
+        .reduce((map, fieldName) => Object.assign(map, { [fieldName]: section }), memo),
+    {},
+  );
+
+
+function findSection(field) {
+  return field.name in fieldToSectionMap ?
+    fieldToSectionMap[field.name] :
+    ADDITIONAL_FIELDS_SECTION;
+}
+
+function bucketFieldsBySection(formFields) {
+  // Make sure to maintain the order by processing these in formFields order
+  return formFields
+    .reduce((form, field) => {
+      const section = findSection(field);
+      const sectionFields = form[section.id] || [];
+
+      sectionFields.push(field);
+      form[section.id] = sectionFields;
+      return form;
+    }, {});
+}
+
+// TODO make this a class so you can pass in the FORM_SECTIONS
+function sectionedFormFromAgencyComponent(agencyComponent) {
+  const fieldsBySection = bucketFieldsBySection(agencyComponent.formFields || []);
+
+  // Grab a list of sections, skipping empty sections
+  const sections = FORM_SECTIONS
+    .concat([ADDITIONAL_FIELDS_SECTION])
+    .filter(section => section.id in fieldsBySection);
+
+  const result = sections
+    .map((section) => {
+      // Use only the form fields in this section
+      const formFields = fieldsBySection[section.id];
+
+      const { jsonSchema, uiSchema } = wfjs.webformFieldsToJsonSchema(formFields, section);
+
+      // Pass a triplet for processing
+      return [section.id, jsonSchema, uiSchema];
+    })
+    .reduce((form, [sectionId, jsonSchema, uiSchema]) => {
+      form.properties[sectionId] = jsonSchema;
+      form.uiSchema[sectionId] = uiSchema;
+      return form;
+    }, { properties: {}, uiSchema: {} });
+
+  return {
+    jsonSchema: {
+      title: agencyComponent.title,
+      type: 'object',
+      properties: result.properties,
+    },
+    uiSchema: result.uiSchema,
+    sections,
+  };
+}
+
+function mergeSectionFormData(formData) {
+  return Object.keys(formData)
+    .reduce(
+      (form, sectionId) => Object.assign(form, formData[sectionId]),
+      {},
+    );
+}
+
+
+export default {
+  mergeSectionFormData,
+  sectionedFormFromAgencyComponent,
+};

--- a/js/util/request_form/sectioned_form.js
+++ b/js/util/request_form/sectioned_form.js
@@ -58,7 +58,7 @@ function sectionedFormFromAgencyComponent(agencyComponent) {
 
   return {
     jsonSchema: {
-      title: agencyComponent.title,
+      title: 'Make your request',
       type: 'object',
       properties: result.properties,
     },

--- a/js/util/request_form/sectioned_form.js
+++ b/js/util/request_form/sectioned_form.js
@@ -1,6 +1,9 @@
 import wfjs from './webform_to_json_schema';
-import { FORM_SECTIONS, ADDITIONAL_FIELDS_SECTION } from './form_sections';
+import FORM_SECTIONS from './form_sections';
 
+
+const ADDITIONAL_FIELDS_SECTION = FORM_SECTIONS
+  .find(section => section.isAgencySpecificFieldSection);
 
 const fieldToSectionMap = FORM_SECTIONS
   .reduce(
@@ -37,7 +40,6 @@ function sectionedFormFromAgencyComponent(agencyComponent) {
 
   // Grab a list of sections, skipping empty sections
   const sections = FORM_SECTIONS
-    .concat([ADDITIONAL_FIELDS_SECTION])
     .filter(section => section.id in fieldsBySection);
 
   const result = sections

--- a/www.foia.gov/_sass/modules/_glossary.scss
+++ b/www.foia.gov/_sass/modules/_glossary.scss
@@ -53,6 +53,17 @@ $z-glossary: 9000; // uswds navigation
   .label {
     color: $color-gray-lightest;
   }
+
+  p {
+    color: $color-white;
+  }
+}
+
+.glossary__item {
+  ol,
+  ul {
+    margin-left: $space-2x;
+  }
 }
 
 .glossary__term {


### PR DESCRIPTION
This adds all the entries that OIP sent over yesterday with a few minor edits. I want to make the `Exemption` glossary entry a robust one that includes all 9 exemptions. Right now they are all entered individually. I also need to add some links, but I'll do that in the next round of edits.